### PR TITLE
Allow creation of DB without user, password, authKey

### DIFF
--- a/src/main/java/org/dsa/iot/rethinkdb/HistoryDbProvider.java
+++ b/src/main/java/org/dsa/iot/rethinkdb/HistoryDbProvider.java
@@ -24,21 +24,29 @@ public class HistoryDbProvider extends DatabaseProvider {
                 Value vPort = event.getParameter("Port", ValueType.NUMBER);
                 Value vDatabase = event.getParameter("Database", ValueType.STRING);
                 Value vTable = event.getParameter("Table", ValueType.STRING);
-                Value vUser = event.getParameter("User", ValueType.STRING);
-                Value vPassword = event.getParameter("Password", ValueType.STRING);
-                Value vAuthKey = event.getParameter("AuthKey", ValueType.STRING);
+                Value vUser = event.getParameter("User");
+                Value vPassword = event.getParameter("Password");
+                Value vAuthKey = event.getParameter("AuthKey");
 
                 String name = StringUtils.encodeName(
                         vHost.getString() + ":" + vPort.getNumber().toString()
                 );
+
+                
                 NodeBuilder builder = createDbNode(name, event);
                 builder.setRoConfig("host", vHost);
                 builder.setRoConfig("port", vPort);
                 builder.setRoConfig("database", vDatabase);
                 builder.setRoConfig("table", vTable);
-                builder.setRoConfig("dbUser", vUser);
-                builder.setRoConfig("dbPassword", vPassword);
-                builder.setRoConfig("dbAuthKey", vAuthKey);
+                if (vUser != null) {
+                    builder.setRoConfig("dbUser", vUser);
+                }
+                if (vPassword != null) {
+                    builder.setRoConfig("dbPassword", vPassword);
+                }
+                if (vAuthKey != null) {
+                    builder.setRoConfig("dbAuthKey", vAuthKey);
+                }
 
                 Value vName = event.getParameter("Name");
                 if (vName != null) {
@@ -101,9 +109,9 @@ public class HistoryDbProvider extends DatabaseProvider {
         Integer port = (Integer) node.getRoConfig("port").getNumber();
         String database = node.getRoConfig("database").getString();
         String table = node.getRoConfig("table").getString();
-        String user = node.getRoConfig("dbUser").getString();
-        String password = node.getRoConfig("dbPassword").getString();
-        String authKey = node.getRoConfig("dbAuthKey").getString();
+        Value userVal = node.getRoConfig("dbUser");
+        Value passwordVal = node.getRoConfig("dbPassword");
+        Value authKeyVal = node.getRoConfig("dbAuthKey");
 
         return new HistoryDb(
                 node.getDisplayName(),
@@ -112,9 +120,9 @@ public class HistoryDbProvider extends DatabaseProvider {
                 port,
                 database,
                 table,
-                user,
-                password,
-                authKey
+                userVal == null ? null : userVal.getString(),
+                passwordVal == null ? null : passwordVal.getString(),
+                authKeyVal == null ? null : authKeyVal.getString()
         );
     }
 


### PR DESCRIPTION
These parameters are not even included as possible parameters in the action declaration. But the way it was written, if they were not specified, the action would fail with "Missing parameter: User".

This makes the parameters optional, looking for a null value instead of always trying to convert to string.